### PR TITLE
add add_string via xxhash3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,7 @@ dependencies = [
  "criterion",
  "rand",
  "serde",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -672,6 +673,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,19 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,7 +330,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -495,6 +508,7 @@ dependencies = [
 name = "ultraloglog"
 version = "0.1.2"
 dependencies = [
+ "ahash",
  "bincode",
  "criterion",
  "rand",
@@ -507,6 +521,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -682,11 +702,31 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.24",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = ["dep:serde", "dep:bincode"]
 [dependencies]
 bincode = { version = "1.3", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-
+xxhash-rust = { version = "0.8", default-features = false, features = ["xxh3"] }
 [dev-dependencies]
 criterion = "0.5"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ xxhash-rust = { version = "0.8", default-features = false, features = ["xxh3"] }
 [dev-dependencies]
 criterion = "0.5"
 rand = "0.8"
+ahash = "0.8"
 
 [[bench]]
 name = "ultraloglog"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,8 @@ const ML_BIAS_CORRECTION_CONSTANT: f64 = 0.48147376527720065;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use xxhash_rust::xxh3::xxh3_64;
+use std::hash::{BuildHasher, Hash, Hasher};
+use xxhash_rust::xxh3::Xxh3;
 
 /// A trait for observing state changes in the UltraLogLog sketch
 pub trait StateChangeObserver {
@@ -105,21 +106,58 @@ impl UltraLogLog {
         ((((reg & 2) | ((reg & 1) << 2)) ^ 7u8) as u64) << (63 - k) >> p
     }
 
-    /// Hashes a byte slice with xxh3_64 and adds it to the sketch.
-    pub fn add_bytes(&mut self, bytes: impl AsRef<[u8]>) -> &mut Self {
-        let hash = xxh3_64(bytes.as_ref());
+    pub fn add_value_with_build_hasher<T, S>(&mut self, value: T, build: &S) -> &mut Self
+    where
+        T: Hash,
+        S: BuildHasher + ?Sized,
+    {
+        // one fresh hasher per call
+        let mut h = build.build_hasher();
+        value.hash(&mut h);
+        // 64‑bit digest
+        let hash = h.finish();
         self.add(hash)
     }
 
-    /// Convenience for &str (delegates to `add_bytes`).
-    pub fn add_str(&mut self, s: &str) -> &mut Self {
-        self.add_bytes(s.as_bytes())
+    /// If `build_hasher` is `None` the method falls back to xxh3‑64 hash function.
+    pub fn add_value_with<T, S>(&mut self, value: T, build_hasher: Option<&S>) -> &mut Self
+    where
+        T: Hash,
+        S: BuildHasher + ?Sized,
+    {
+        match build_hasher {
+            Some(b) => self.add_value_with_build_hasher(value, b),
+            None => self.add_value(value),
+        }
     }
+
+    pub fn add_value<T: Hash>(&mut self, value: T) -> &mut Self {
+        // 64‑bit xxh3 hash
+        let mut h = Xxh3::default();
+        value.hash(&mut h);
+        let hash = h.finish();
+        self.add(hash)
+    }
+    /// Same as [`Self::add_value`] but notifies a `StateChangeObserver`.
+    pub fn add_value_with_observer<T, O>(
+        &mut self,
+        value: T,
+        mut observer: Option<&mut O>,
+    ) -> &mut Self
+    where
+        T: Hash,
+        O: StateChangeObserver,
+    {
+        let mut h = Xxh3::default();
+        value.hash(&mut h);
+        let hash = h.finish();
+        self.add_with_observer(hash, observer.take())
+    }
+
     /// Adds a new element represented by a 64-bit hash value to this sketch.
     ///
     /// In order to get good estimates, it is important that the hash value is calculated using a
     /// high-quality hash algorithm.
-    
     pub fn add(&mut self, hash_value: u64) -> &mut Self {
         struct NoopObserver;
         impl StateChangeObserver for NoopObserver {
@@ -142,7 +180,7 @@ impl UltraLogLog {
         let mut hash_prefix = Self::unpack(old_state);
         // This shift left is not working in Rust, but works in Java
         //hash_prefix |= 1u64 << (nlz + (64 - q)); // (nlz + (64-q)) = (nlz + p) in {p, ... 63}
-        let exp = (nlz + (64 - q)) as u32;          // exp is 0‑64
+        let exp = (nlz + (64 - q)) as u32; // exp is 0‑64
         hash_prefix |= 1u64.wrapping_shl(exp & 63); // shift modulo 64
         let new_state = Self::pack(hash_prefix);
 
@@ -885,6 +923,7 @@ fn solve_maximum_likelihood_equation(a: f64, b: &[i32], max_k: i32, eps: f64) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ahash::RandomState;
 
     #[test]
     fn test_create_ultraloglog() {
@@ -980,23 +1019,36 @@ mod tests {
         remove_file(file_path).ok();
     }
     #[test]
-    fn test_add_strings() {
-        // p = 10  ⇒  1 024 registers – plenty of head‑room for just 3 items
-        let mut ull = UltraLogLog::new(5).expect("Failed to create ULL");
+    fn test_xxhash3() {
+        let mut ull = UltraLogLog::new(6).unwrap();
 
-        // Ingest three unique strings via the xxh3‑powered helper
-        ull.add_str("apple")
-        .add_str("banana")
-        .add_str("cherry");
+        ull.add_value("apple")
+            .add_value("banana")
+            .add_value("cherry")
+            .add_value("033");
 
-        let estimate = ull.get_distinct_count_estimate();
-
-        // UltraLogLog should be almost exact at such a tiny cardinality.
-        // Allow a ±0.1 margin to avoid flaky CI failures in extreme hash‑collision cases.
+        let est = ull.get_distinct_count_estimate();
         assert!(
-            (estimate - 3.0).abs() < 0.1,
-            "estimate {:.3} deviates too much from true count 3",
-            estimate
+            (est - 4.0).abs() < 0.1,
+            "estimate {:.3} deviates from true count 3",
+            est
+        );
+    }
+    #[test]
+    fn test_custom_ahash_hasher() {
+        let ahash = RandomState::with_seeds(1, 2, 3, 4);
+
+        let mut ull = UltraLogLog::new(6).unwrap();
+
+        ull.add_value_with_build_hasher("apple", &ahash)
+            .add_value_with_build_hasher("banana", &ahash)
+            .add_value_with_build_hasher("cherry", &ahash);
+
+        let est = ull.get_distinct_count_estimate();
+        assert!(
+            (est - 3.0).abs() < 0.1,
+            "estimate {:.3} deviates from true count 3",
+            est
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,8 +178,6 @@ impl UltraLogLog {
 
         let old_state = self.state[idx];
         let mut hash_prefix = Self::unpack(old_state);
-        // This shift left is not working in Rust, but works in Java
-        //hash_prefix |= 1u64 << (nlz + (64 - q)); // (nlz + (64-q)) = (nlz + p) in {p, ... 63}
         let exp = (nlz + (64 - q)) as u32; // exp is 0‑64
         hash_prefix |= 1u64.wrapping_shl(exp & 63); // shift modulo 64
         let new_state = Self::pack(hash_prefix);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -992,7 +992,7 @@ mod tests {
         let estimate = ull.get_distinct_count_estimate();
 
         // UltraLogLog should be almost exact at such a tiny cardinality.
-        // Allow a ±0.5 margin to avoid flaky CI failures in extreme hash‑collision cases.
+        // Allow a ±0.1 margin to avoid flaky CI failures in extreme hash‑collision cases.
         assert!(
             (estimate - 3.0).abs() < 0.1,
             "estimate {:.3} deviates too much from true count 3",


### PR DESCRIPTION
Hi Ruihang, 
Use xxhash3_rust for hashing strings. Some bug fix for bit shift under Rust for full 64bit hash, we need wrapping shift. 

Let me know your comments.

Best,
Jianshu