### PR TITLE
register bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy 0.7.35",
@@ -196,13 +196,24 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -216,22 +227,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
-
-[[package]]
-name = "indoc"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "is-terminal"
@@ -300,15 +299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,12 +354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ae9b6e611577fd2a9a74fdffb9f6913912538ea88a610bec6bde36081a82f3"
 
 [[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,69 +372,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
-dependencies = [
- "cfg-if",
- "indoc",
- "libc",
- "memoffset",
- "once_cell",
- "portable-atomic",
- "pyo3-build-config",
- "pyo3-ffi",
- "pyo3-macros",
- "unindent",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
-dependencies = [
- "once_cell",
- "target-lexicon",
-]
-
-[[package]]
-name = "pyo3-ffi"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
-dependencies = [
- "libc",
- "pyo3-build-config",
-]
-
-[[package]]
-name = "pyo3-macros"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
-dependencies = [
- "proc-macro2",
- "pyo3-macros-backend",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pyo3-macros-backend"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
-dependencies = [
- "heck",
- "proc-macro2",
- "pyo3-build-config",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,13 +382,37 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+ "rand_pcg",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -482,11 +427,20 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -494,6 +448,24 @@ name = "rand_core"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
+]
 
 [[package]]
 name = "rayon"
@@ -613,6 +585,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming_algorithms"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85d53471a52d669b6c87a304df3702c7466b5623da38c7fd43241a9257dd551f"
+dependencies = [
+ "bincode",
+ "rand 0.7.3",
+ "serde",
+ "twox-hash",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,12 +627,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,17 +637,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "rand 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
 name = "ultraloglog"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "ahash",
  "bincode",
  "criterion",
  "komihash",
  "polymur-hash",
- "pyo3",
- "rand",
+ "rand 0.8.5",
  "serde",
+ "streaming_algorithms",
  "t1ha",
  "wyhash",
  "xxhash-rust",
@@ -673,12 +669,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "version_check"
@@ -695,6 +685,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ultraloglog"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Ruihang Xia <waynestxia@gmail.com>", "Jianshu Zhao <jianshuzhao@yahoo.com>"]
@@ -10,20 +10,14 @@ repository = "https://github.com/waynexia/ultraloglog"
 keywords = ["ultraloglog", "algorithm", "sketch", "probabilistic", "hyperloglog"]
 categories = ["data-structures", "algorithms"]
 
-[lib]
-name = "ultraloglog"
-crate-type = ["cdylib", "rlib"]
-
 [features]
 default = []
 serde = ["dep:serde", "dep:bincode"]
-python = ["dep:pyo3"]
 
 [dependencies]
 bincode = { version = "1.3", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 xxhash-rust = { version = "0.8", default-features = false, features = ["xxh3"] }
-pyo3 = { version = "0.22", features = ["extension-module"], optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
@@ -33,6 +27,7 @@ komihash = "0.4.1"
 polymur-hash = "0.2.2"
 wyhash = "0.6.0"
 t1ha = "0.1.2"
+streaming_algorithms = {version = "0.3.3", features = ["serde", "stdsimd"]}
 
 [[bench]]
 name = "ultraloglog"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/waynexia/ultraloglog"
 keywords = ["ultraloglog", "algorithm", "sketch", "probabilistic", "hyperloglog"]
 categories = ["data-structures", "algorithms"]
 
+[lib]
+name = "ultraloglog"
+crate-type = ["cdylib", "rlib"]
+
 [features]
 default = []
 serde = ["dep:serde", "dep:bincode"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,13 @@ categories = ["data-structures", "algorithms"]
 [features]
 default = []
 serde = ["dep:serde", "dep:bincode"]
+python = ["dep:pyo3"]
 
 [dependencies]
 bincode = { version = "1.3", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 xxhash-rust = { version = "0.8", default-features = false, features = ["xxh3"] }
+pyo3 = { version = "0.22", features = ["extension-module"], optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,6 @@
 // https://github.com/dynatrace-oss/hash4j/
 // See the paper "UltraLogLog: A Practical and More Space-Efficient Alternative to HyperLogLog for Approximate Distinct Counting"
 
-#[cfg(feature = "python")]
-mod python;
-#[cfg(feature = "python")]
-pub use python::*;
-
 // Constants for UltraLogLog implementation
 const MIN_P: u32 = 3;
 const MAX_P: u32 = 26; // 32 - 6 (same as Java implementation)
@@ -108,7 +103,12 @@ impl UltraLogLog {
             return 1u64 << (64 - p);
         }
         let k = 1i32.wrapping_sub(p as i32) + ((reg >> 2) as i32);
-        ((((reg & 2) | ((reg & 1) << 2)) ^ 7u8) as u64) << (63 - k) >> p
+
+        // Java’s `<< ~k`  ==>  shift by ((!k as u32) & 63)
+        let shift = ((!k) as u32) & 63;
+        let head = (((reg & 2) | ((reg & 1) << 2)) ^ 7u8) as u64;
+
+        (head << shift) >> p
     }
 
     pub fn add_value_with_build_hasher<T, S>(&mut self, value: T, build: &S) -> &mut Self
@@ -178,21 +178,28 @@ impl UltraLogLog {
         observer: Option<&mut T>,
     ) -> &mut Self {
         let q = (self.state.len() as u64 - 1).leading_zeros(); // q = 64 - p
+        let p = 64 - q;
+
         let idx = (hash_value >> q) as usize;
-        let nlz = (!hash_value << q).leading_zeros(); // nlz in {0, 1, ..., 64-p}
+
+        // nlz = lz( ~ ( (~hash) << p ) ), guaranteed in 0..=64-p
+        let nlz = (!((!hash_value) << p)).leading_zeros();
 
         let old_state = self.state[idx];
         let mut hash_prefix = Self::unpack(old_state);
-        let exp = (nlz + (64 - q)) as u32; // exp is 0‑64
-        hash_prefix |= 1u64.wrapping_shl(exp & 63); // shift modulo 64
+
+        // place the bit at nlz + p - 1 (mod 64)
+        let exp = nlz + p - 1;
+        hash_prefix |= 1u64.wrapping_shl(exp & 63);
+
         let new_state = Self::pack(hash_prefix);
 
         if let Some(obs) = observer {
             if new_state != old_state {
-                let p = 64 - q;
+                let p_u32 = p; // already u32
                 obs.state_changed(
-                    (Self::get_scaled_register_change_probability(old_state, p)
-                        - Self::get_scaled_register_change_probability(new_state, p))
+                    (Self::get_scaled_register_change_probability(old_state, p_u32)
+                        - Self::get_scaled_register_change_probability(new_state, p_u32))
                         as f64
                         * 2f64.powi(-64),
                 );
@@ -205,25 +212,31 @@ impl UltraLogLog {
 
     /// Computes a token from a given 64-bit hash value.
     pub fn compute_token(hash_value: u64) -> u32 {
-        // In the Java implementation this uses DistinctCountUtil.computeToken1
-        // For now we'll implement a simple version
-        (hash_value >> 32) as u32
+        let idx = (hash_value >> 38) as u32; // top 26 bits
+        let nlz = (!((!hash_value) << 26)).leading_zeros(); // in 0..=38
+        (idx << 6) | (nlz & 0x3f)
     }
 
-    /// Adds a new element represented by a 32-bit token
+    /// Matches DistinctCountUtil.reconstructHash
+    pub fn reconstruct_hash_from_token(token: u32) -> u64 {
+        let idx = (token & 0xFFFF_FFC0) as u64; // bits 31..6
+        let nlz = (token & 0x3f) as u32; // bits 5..0
+                                         // 38 ones shifted logically by nlz (use only nlz for the >>> on a 64-bit value)
+        let low = (0x3FFF_FFFF_FFu64) >> nlz; // 0x3FFFFFFFFF = (1<<38) - 1      // 38 ones
+        (idx << 32) | low
+    }
+
     pub fn add_token(&mut self, token: u32) -> &mut Self {
-        // Reconstruct hash from token (simplified version)
-        let hash = (token as u64) << 32;
+        let hash = Self::reconstruct_hash_from_token(token);
         self.add(hash)
     }
 
-    /// Adds a new element represented by a 32-bit token with observer
     pub fn add_token_with_observer<T: StateChangeObserver>(
         &mut self,
         token: u32,
         observer: Option<&mut T>,
     ) -> &mut Self {
-        let hash = (token as u64) << 32;
+        let hash = Self::reconstruct_hash_from_token(token);
         self.add_with_observer(hash, observer)
     }
 
@@ -284,8 +297,9 @@ impl UltraLogLog {
                     j += 1;
                     for k in 1..k_upper_bound {
                         if other_data[j] != 0 {
-                            hash_prefix |= 1u64
-                                << (k.leading_zeros() as i32 + other_p_minus_one as i32) as u32;
+                            let shift =
+                                ((k.leading_zeros() as i32 + other_p_minus_one as i32) as u32) & 63;
+                            hash_prefix |= 1u64.wrapping_shl(shift);
                         }
                         j += 1;
                     }
@@ -455,9 +469,14 @@ impl OptimalFGRAEstimator {
         let alpha = m + 3 * (c0 + c4 + c8 + c10);
         let beta = m - c0 - c4;
         let gamma = 4 * c0 + 2 * c4 + 3 * c8 + c10;
-        let quad_root_z = (((beta * beta) as f64 + 4.0 * (alpha * gamma) as f64).sqrt()
-            - beta as f64)
-            / (2.0 * alpha as f64);
+
+        // Do math in f64 to avoid i32 overflow in debug builds.
+        let alpha_f = alpha as f64;
+        let beta_f = beta as f64;
+        let gamma_f = gamma as f64;
+
+        let quad_root_z =
+            (((beta_f * beta_f) + 4.0 * (alpha_f * gamma_f)).sqrt() - beta_f) / (2.0 * alpha_f);
         let root_z = quad_root_z * quad_root_z;
         root_z * root_z
     }
@@ -537,9 +556,15 @@ impl OptimalFGRAEstimator {
         let alpha = m + 3 * (c4w0 + c4w1 + c4w2 + c4w3);
         let beta = c4w0 + c4w1 + 2 * (c4w2 + c4w3);
         let gamma = m + 2 * c4w0 + c4w2 - c4w3;
-        ((((beta * beta) as f64 + 4.0 * (alpha * gamma) as f64).sqrt() - beta as f64)
-            / (2.0 * alpha as f64))
-            .sqrt()
+
+        // Same widening to f64 here.
+        let alpha_f = alpha as f64;
+        let beta_f = beta as f64;
+        let gamma_f = gamma as f64;
+
+        let inner =
+            (((beta_f * beta_f) + 4.0 * (alpha_f * gamma_f)).sqrt() - beta_f) / (2.0 * alpha_f);
+        inner.sqrt()
     }
 
     fn phi(z: f64, z_square: f64) -> f64 {
@@ -1272,7 +1297,7 @@ mod tests {
             }
         }
 
-        // ── Sketch four keys and check the estimate ───────────────────────────────
+        // Sketch four keys and check the estimate
         let builder = T1ha0Avx2Build::default();
         let mut ull = UltraLogLog::new(8).unwrap();
 
@@ -1286,6 +1311,160 @@ mod tests {
             (est - 4.0).abs() < 0.1,
             "t1ha0-avx2 estimate {:.3} deviates too much from 4",
             est
+        );
+    }
+    #[test]
+    fn ull_vs_hll_space() {
+        use streaming_algorithms::HyperLogLog as HLL;
+
+        const N: u64 = 100_000;
+        const TRIALS: usize = 51; // odd ⇒ clean medians; bump for more stability
+        const TARGET_REL_ERR: f64 = 0.015; // 1.5% absolute relative error target
+        const HLL_MIN_P: u8 = 4;
+        const HLL_MAX_P: u8 = 16;
+
+        // deterministic 64-bit “hash” stream (SplitMix64)
+        #[inline]
+        fn splitmix64(mut x: u64) -> u64 {
+            x = x.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = x;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            z ^ (z >> 31)
+        }
+        fn make_hashes(seed: u64) -> Vec<u64> {
+            (0..N).map(|i| splitmix64(seed.wrapping_add(i))).collect()
+        }
+
+        // single-run error helpers
+        fn err_ull(p: u32, keys: &[u64]) -> f64 {
+            let mut ull = crate::UltraLogLog::new(p).expect("valid ULL p");
+            for &h in keys {
+                ull.add(h);
+            } // ULL expects 64-bit hash
+            let est = ull.get_distinct_count_estimate();
+            (est - N as f64).abs() / (N as f64)
+        }
+        fn err_hll(p: u8, keys: &[u64]) -> f64 {
+            let mut hll = HLL::<u64>::with_p(p);
+            for &h in keys {
+                hll.push_hash64(h);
+            } // avoid rehash inside HLL
+            let est = hll.len();
+            (est - N as f64).abs() / (N as f64)
+        }
+
+        // generate deterministic per-trial seeds
+        let mut seeds = Vec::with_capacity(TRIALS);
+        let mut s = 0x1234_5678_9ABC_DEF0u64;
+        for _ in 0..TRIALS {
+            s = s
+                .wrapping_mul(0x9E3779B97F4A7C15)
+                .wrapping_add(0xD1B54A32D192ED03);
+            seeds.push(s);
+        }
+
+        // per-trial minimal p and Δp
+        let mut deltas: Vec<i32> = Vec::with_capacity(TRIALS);
+        let mut per_trial_rows: Vec<(usize, u32, u8, i32)> = Vec::with_capacity(TRIALS);
+
+        'trial: for (ti, &seed) in seeds.iter().enumerate() {
+            let keys = make_hashes(seed);
+
+            // find minimal p for ULL
+            let mut p_ull_opt = None;
+            for p in crate::MIN_P..=crate::MAX_P {
+                if err_ull(p, &keys) <= TARGET_REL_ERR {
+                    p_ull_opt = Some(p);
+                    break;
+                }
+            }
+            let p_ull = match p_ull_opt {
+                Some(p) => p,
+                None => continue 'trial, // skip if not achievable (shouldn’t happen for these N/targets)
+            };
+
+            // find minimal p for HLL
+            let mut p_hll_opt = None;
+            for p in HLL_MIN_P..=HLL_MAX_P {
+                if err_hll(p, &keys) <= TARGET_REL_ERR {
+                    p_hll_opt = Some(p);
+                    break;
+                }
+            }
+            let p_hll = match p_hll_opt {
+                Some(p) => p,
+                None => continue 'trial,
+            };
+
+            let dp = p_hll as i32 - p_ull as i32; // Δp = HLL − ULL
+            deltas.push(dp);
+            per_trial_rows.push((ti, p_ull, p_hll, dp));
+        }
+
+        if deltas.is_empty() {
+            panic!("no successful trials; try relaxing TARGET_REL_ERR or increasing p ranges");
+        }
+
+        // Δp histogram
+        use std::collections::BTreeMap;
+        let mut hist: BTreeMap<i32, usize> = BTreeMap::new();
+        for &dp in &deltas {
+            *hist.entry(dp).or_default() += 1;
+        }
+
+        // medians & means
+        let mut d_sorted = deltas.clone();
+        d_sorted.sort_unstable();
+        let median_dp = d_sorted[d_sorted.len() / 2] as f64;
+        let mean_dp = deltas.iter().copied().map(|k| k as f64).sum::<f64>() / deltas.len() as f64;
+
+        // Geometric-mean ratios via Δp:
+        // naive  = 2^{-Δp}, packed = (4/3) * 2^{-Δp}
+        let gm_naive = 2f64.powf(-mean_dp);
+        let gm_packed = (4.0 / 3.0) * gm_naive;
+
+        // Median ratios via median Δp (handy intuition):
+        let med_naive = 2f64.powf(-median_dp);
+        let med_packed = (4.0 / 3.0) * med_naive;
+
+        // Pretty print
+        println!("Trials: {}", deltas.len());
+        println!("N = {}", N);
+        println!(
+            "Target absolute relative error: {:.2}%",
+            TARGET_REL_ERR * 100.0
+        );
+        println!();
+        println!("Δp histogram (HLL − ULL):");
+        for (dp, cnt) in hist {
+            println!("  Δp={:>+2}: {:>2} trial(s)", dp, cnt);
+        }
+        println!();
+
+        println!(
+            "Geometric-mean ratios over trials:\n  \
+            packed (ULL=8b, HLL=6b): {:.3}  → savings ≈ {:.1}%\n  \
+            naive  (1B/reg)        : {:.3}  → savings ≈ {:.1}%",
+            gm_packed,
+            (1.0 - gm_packed) * 100.0,
+            gm_naive,
+            (1.0 - gm_naive) * 100.0
+        );
+        println!(
+            "Median ratios (from median Δp={}):\n  \
+            packed: {:.3}  → savings ≈ {:.1}%\n  \
+            naive : {:.3}  → savings ≈ {:.1}%",
+            median_dp as i32,
+            med_packed,
+            (1.0 - med_packed) * 100.0,
+            med_naive,
+            (1.0 - med_naive) * 100.0
+        );
+        assert!(
+            gm_packed <= 0.80,
+            "expected ≲ 0.80 (≈≥20% saving), got {:.3}",
+            gm_packed
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,11 @@
 // https://github.com/dynatrace-oss/hash4j/
 // See the paper "UltraLogLog: A Practical and More Space-Efficient Alternative to HyperLogLog for Approximate Distinct Counting"
 
+#[cfg(feature = "python")]
+mod python;
+#[cfg(feature = "python")]
+pub use python::*;
+
 // Constants for UltraLogLog implementation
 const MIN_P: u32 = 3;
 const MAX_P: u32 = 26; // 32 - 6 (same as Java implementation)


### PR DESCRIPTION
registers get updated in the wrong positions:

With the wrong nlz (computed from q instead of p) and the off-by-one shift, we set the wrong bit in the prefix word for many updates. That corrupts the register distribution, so the FGRA estimator sees the wrong histogram and returns a biased estimate. 

More test to compare with HLL in streaming_algorithms::HyperLogLog for space.  

Let me know your thoughts. 